### PR TITLE
feat: adding ssh pass through for git #3

### DIFF
--- a/deployments/gitea/templates/docker-compose.yml
+++ b/deployments/gitea/templates/docker-compose.yml
@@ -12,6 +12,12 @@ services:
       # Specifies the user ID under which the Gitea service will run. This improves security by avoiding root privileges.
       - USER_GID=1000
       # Specifies the group ID under which the Gitea service will run. Ensure this matches the NFS directory permissions.
+      - SSH_PORT=22
+      # Explicitly sets the SSH port inside the container to 22 to ensure Gitea's SSH service uses this port.
+      - SSH_DOMAIN=git.{{ general.domain }}
+      # Sets the SSH domain for repository URLs. This helps Gitea generate correct SSH URLs.
+      - SSH_LISTEN_PORT=22
+      # Configures the internal port that Gitea's SSH service listens on.
 
     restart: always
     # Ensures the container automatically restarts if it stops unexpectedly.
@@ -38,6 +44,7 @@ services:
       # The number of replicas (instances) of the service to run. In this case, only one instance is deployed.
 
       labels:
+        # HTTP/HTTPS routing
         - "traefik.enable=true"
         # Enables Traefik integration for this service.
         - "traefik.http.routers.git.entrypoints=web"
@@ -64,6 +71,16 @@ services:
         # Ensures that the original `Host` header is passed to the Gitea service.
         - "traefik.docker.network=proxy"
         # Specifies the Docker network (`proxy`) that Traefik should use to communicate with the service.
+        
+        # SSH routing configuration
+        - "traefik.tcp.routers.git-ssh.entrypoints=ssh"
+        # Defines the SSH entry point (port 2222) for the `git-ssh` router.
+        - "traefik.tcp.routers.git-ssh.rule=HostSNI(`*`)"
+        # Uses a catch-all rule for SSH traffic as SSH doesn't use SNI headers.
+        - "traefik.tcp.routers.git-ssh.service=git-ssh"
+        # Associates the `git-ssh` router with the `git-ssh` service.
+        - "traefik.tcp.services.git-ssh.loadbalancer.server.port=22"
+        # Specifies the internal port (22) of the Gitea service for SSH access.
 
 networks:
   proxy:

--- a/deployments/traefik/templates/docker-compose.yaml
+++ b/deployments/traefik/templates/docker-compose.yaml
@@ -42,6 +42,8 @@ services:
       # Configures the HTTP entry point on port 80.
       - "--entrypoints.websecure.address=:443"
       # Configures the HTTPS entry point on port 443.
+      - "--entrypoints.ssh.address=:22"
+      # Configures the SSH entry point on port 22 for forwarding SSH traffic to services.
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
       # Redirects HTTP traffic to HTTPS.
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
@@ -122,6 +124,8 @@ services:
       # Maps port 443 on the host to port 443 in the container for HTTPS traffic.
       - "8080:8080"
       # Maps port 8080 on the host to port 8080 in the container for the Traefik dashboard.
+      - "22:22"
+      # Maps port 22 on the host to port 22 in the container for SSH traffic.
 
     environment:
       - CF_API_EMAIL_FILE=/run/secrets/cf_email


### PR DESCRIPTION
- allow users to use git tea with ssh keys
- added new entrypoint to traefik
- added configuration to gitea to listen to ssh port