### PR TITLE
4 restrict network file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ cluster:
     docker:
     manager:
 
+nfs_servers:
+  hosts:
+    nfs:
+
 docker:
     hosts:
       docker-[01:06]:

--- a/docker-swarm/create.yml
+++ b/docker-swarm/create.yml
@@ -3,7 +3,7 @@
 # Swarm initialization, and network setup. It uses roles to modularize tasks for better reusability and maintainability.
 
 - name: Setup NFS
-  hosts: nfs  # Target the NFS server group defined in the inventory.
+  hosts: nfs_servers  # Target the NFS server group defined in the inventory.
   become: true  # Execute tasks with elevated privileges (sudo).
   roles:
   - setup_nfs_server  # Use the `setup_nfs_server` role to configure the NFS server.

--- a/docker-swarm/group_vars/all.yml
+++ b/docker-swarm/group_vars/all.yml
@@ -18,6 +18,12 @@ registry_url: "{{ vault_registry_url }}" # The URL of the Docker registry.
 # Replace "vault_registry_url" with the actual registry URL if not using a vault.
 # Example: "https://index.docker.io/v1/" for Docker Hub or a custom URL for private registries.
 
+# NFS Server Configuration
+# This variable stores the hostname or IP address of the NFS server
+# It is dynamically set to the first host in the 'nfs_servers' group from the inventory
+# This allows the playbook to automatically use the correct NFS server without hardcoding IP addresses
+nfs_server_host: "{{ groups['nfs_servers'][0] }}"
+
 # NFS access restriction configuration
 # This variable defines which hosts/networks are allowed to access the NFS exports
 # It is used in the exports.j2 template to configure the NFS server's exports file

--- a/docker-swarm/group_vars/all.yml
+++ b/docker-swarm/group_vars/all.yml
@@ -18,6 +18,27 @@ registry_url: "{{ vault_registry_url }}" # The URL of the Docker registry.
 # Replace "vault_registry_url" with the actual registry URL if not using a vault.
 # Example: "https://index.docker.io/v1/" for Docker Hub or a custom URL for private registries.
 
+# NFS access restriction configuration
+# This variable defines which hosts/networks are allowed to access the NFS exports
+# It is used in the exports.j2 template to configure the NFS server's exports file
+# Format: IP address or hostname with optional netmask or CIDR notation
+#
+# Common values:
+# - "192.168.1.0/24"            # Allow access from entire subnet (192.168.1.0 through 192.168.1.255)
+# - "10.0.0.5"                  # Allow access from a single IP address
+# - "*.example.com"             # Allow access from all hosts in example.com domain
+# - "@trusted_network"          # Allow access from a netgroup (if NIS is configured)
+# - "10.0.0.0/8 192.168.0.0/16" # Multiple networks separated by spaces
+#
+# Security considerations:
+# - Avoid using "*" which allows access from any host, unless behind a secure firewall
+# - Consider using more restrictive options for production environments
+# - When possible, explicitly list the IPs of Docker Swarm nodes instead of entire subnets
+# - For high-security environments, also consider implementing firewall rules (iptables)
+#
+# This value is retrieved from Ansible Vault for security
+nfs_restriction: "{{ vault_nfs_restriction }}"
+
 # Security Note:
 # - Always use Ansible Vault to store sensitive information like usernames, passwords, and URLs.
 # - Avoid hardcoding sensitive credentials directly in this file to prevent unauthorized access.

--- a/docker-swarm/roles/mount_nfs/tasks/main.yml
+++ b/docker-swarm/roles/mount_nfs/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: Mount an NFS volume
   ansible.posix.mount:
-    src: "nfs.local:/exports/docker"  # The NFS server and export path to mount.
+    src: "{{ nfs_server_host }}:/exports/docker"  # The NFS server and export path to mount.
     path: /mnt/nfs/docker  # The local path where the NFS volume will be mounted.
     opts: rw,sync,hard  # Mount options:
     # - `rw`: Mount the volume with read and write permissions.
@@ -36,7 +36,7 @@
     # - `hard`: Retry indefinitely if the server becomes unavailable.
     state: mounted  # Ensure the volume is mounted.
     fstype: nfs  # Specify the file system type as NFS.
-  # This task mounts the NFS volume to the specified local directory.
+  # This task mounts the NFS volume to the specified local directory using the hostname/IP from inventory.
 
 # Notes:
 # - Ensure that the NFS server (`nfs.local`) is properly configured and accessible from the target node.

--- a/docker-swarm/roles/setup_nfs_server/templates/exports.j2
+++ b/docker-swarm/roles/setup_nfs_server/templates/exports.j2
@@ -1,1 +1,1 @@
-/exports/docker *(rw,sync,no_subtree_check,no_root_squash)
+/exports/docker {{ nfs_restriction }}(rw,sync,no_subtree_check,no_root_squash)


### PR DESCRIPTION
This pull request introduces changes to enhance the configuration and flexibility of NFS (Network File System) integration in the Docker Swarm setup. The updates make the setup more dynamic by leveraging inventory-based variables and improve security by allowing configurable access restrictions for NFS exports.

### NFS Configuration Enhancements:

* **Dynamic NFS Server Targeting**: Updated the inventory and playbook to use a new `nfs_servers` group, enabling dynamic targeting of NFS servers instead of hardcoding specific hosts. (`README.md` - [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49-R52) `docker-swarm/create.yml` - [[2]](diffhunk://#diff-a0e60075c3192166ad7e5f9c8a6aac82db7b5ee0846fb271eeaaafc02fc4a7efL6-R6)
* **Dynamic Hostname Resolution**: Introduced the `nfs_server_host` variable in `group_vars/all.yml` to dynamically resolve the NFS server's hostname or IP address from the inventory. This eliminates the need for hardcoding server details. (`docker-swarm/group_vars/all.yml` - [docker-swarm/group_vars/all.ymlR21-R47](diffhunk://#diff-f1cb21613dd01c30b4a36bda84907e0f2cffa41a3ababb020f520cb0c0be46dfR21-R47))
* **Mount Task Update**: Modified the NFS mount task to use the `nfs_server_host` variable, ensuring the mount operation dynamically adapts to the inventory configuration. (`docker-swarm/roles/mount_nfs/tasks/main.yml` - [docker-swarm/roles/mount_nfs/tasks/main.ymlL31-R39](diffhunk://#diff-ea9d1639d1a46859a486b53c2260fd89f5e437659208522c04dd690036f6892aL31-R39))

### Security Improvements:

* **Configurable Access Restrictions**: Added the `nfs_restriction` variable for defining access restrictions in the NFS exports file. This allows fine-grained control over which hosts or networks can access the NFS server. (`docker-swarm/group_vars/all.yml` - [[1]](diffhunk://#diff-f1cb21613dd01c30b4a36bda84907e0f2cffa41a3ababb020f520cb0c0be46dfR21-R47) `docker-swarm/roles/setup_nfs_server/templates/exports.j2` - [[2]](diffhunk://#diff-1bf8b83942bbb87458b3d90786eceb0b0caf4ee955fc6b7f490f9f5e84cc4694L1-R1)