### PR TITLE
#5 restart cluster and nfs tweaks

### DIFF
--- a/docker-swarm/group_vars/all.yml
+++ b/docker-swarm/group_vars/all.yml
@@ -22,6 +22,9 @@ registry_url: "{{ vault_registry_url }}" # The URL of the Docker registry.
 # This variable stores the hostname or IP address of the NFS server
 # It is dynamically set to the first host in the 'nfs_servers' group from the inventory
 # This allows the playbook to automatically use the correct NFS server without hardcoding IP addresses
+# Note: This dynamic resolution relies on the 'ansible_default_ipv4' variable being set on the NFS server host.
+#       Ensure that the NFS server host has a default IPv4 address configured and that this variable is available
+#       in the inventory. Ansible typically sets this variable automatically if the host has a default IPv4 address.
 nfs_server_host: "{{ hostvars[groups['nfs_servers'][0]].ansible_default_ipv4.address }}"
 
 # NFS access restriction configuration

--- a/docker-swarm/group_vars/all.yml
+++ b/docker-swarm/group_vars/all.yml
@@ -22,7 +22,7 @@ registry_url: "{{ vault_registry_url }}" # The URL of the Docker registry.
 # This variable stores the hostname or IP address of the NFS server
 # It is dynamically set to the first host in the 'nfs_servers' group from the inventory
 # This allows the playbook to automatically use the correct NFS server without hardcoding IP addresses
-nfs_server_host: "{{ groups['nfs_servers'][0] }}"
+nfs_server_host: "{{ hostvars[groups['nfs_servers'][0]].ansible_default_ipv4.address }}"
 
 # NFS access restriction configuration
 # This variable defines which hosts/networks are allowed to access the NFS exports

--- a/docker-swarm/roles/mount_nfs/tasks/main.yml
+++ b/docker-swarm/roles/mount_nfs/tasks/main.yml
@@ -26,6 +26,13 @@
     group: nogroup  # Set the directory group to `nogroup`.
   # This task ensures that the directory for mounting the NFS volume exists with the correct permissions.
 
+- name: Display NFS server information
+  ansible.builtin.debug:
+    msg: "NFS Server: {{ nfs_server_host }}"
+    verbosity: 0  # Always show this message regardless of verbosity level
+  # This task displays the NFS server host information for verification and debugging purposes
+  # It helps ensure that the correct server is being used before attempting to mount
+
 - name: Mount an NFS volume
   ansible.posix.mount:
     src: "{{ nfs_server_host }}:/exports/docker"  # The NFS server and export path to mount.

--- a/maintenance/restart-cluster.yml
+++ b/maintenance/restart-cluster.yml
@@ -1,0 +1,54 @@
+---
+# This playbook is responsible for restarting all nodes in the cluster in a controlled manner.
+# It targets all hosts in the "cluster" group and ensures that the reboot process is handled properly,
+# including verification that the systems successfully come back online after rebooting.
+#
+# Use Cases:
+# - After system updates that require a reboot
+# - To clear memory leaks or system state issues
+# - As part of scheduled maintenance procedures
+# - To apply kernel updates or configuration changes
+
+- hosts: cluster  # Target all hosts in the "cluster" group defined in the inventory.
+  become: true    # Run all tasks with elevated privileges (e.g., sudo) to allow system reboot.
+
+  tasks:  # Define the list of tasks to execute.
+
+    # Task 1: Reboot the system
+    - name: Reboot system
+      reboot:
+        # The 'reboot' module handles the system restart and waits for it to come back online
+        # Default parameters (which can be added explicitly if needed):
+        # - msg: Optional message for users logged into the system
+        # - pre_reboot_delay: Seconds to wait before issuing reboot command (default: 0)
+        # - post_reboot_delay: Seconds to wait after the reboot (default: 0)
+        # - connect_timeout: Maximum seconds to wait for connection during reboot (default: 300)
+        # - test_command: Command to run to verify the system is operational (default: whoami)
+        # - reboot_timeout: Maximum seconds to wait for machine to reboot (default: 600)
+      register: reboot_result  # Store the result of the reboot operation for later verification
+      # When this task completes successfully, it means:
+      # 1. The reboot command was issued successfully
+      # 2. The system has gone down for reboot
+      # 3. The system has come back online
+      # 4. Ansible has successfully reconnected to it
+
+    # Task 2: Verify the reboot was successful
+    - name: Assert reboot succeeded  
+      assert:
+        that:
+          - reboot_result.rebooted == true  # Verify that the system was actually rebooted
+        # This assertion fails if:
+        # - The reboot command did not execute properly
+        # - The system did not come back online within the timeout period
+        # - Ansible could not reconnect to the host after reboot
+        # The assertion provides clear feedback in the playbook results
+        # rather than just moving on to the next tasks
+        success_msg: "System successfully rebooted and is now online"
+        fail_msg: "System reboot failed or did not complete within the expected timeframe"
+
+# Notes:
+# - This playbook will cause temporary downtime for all cluster nodes
+# - Consider using a rolling reboot strategy for production environments to maintain service availability
+# - The playbook does not check for running workloads before reboot - add pre-checks if needed
+# - Adjust timeout parameters if your systems take longer to reboot than the default timeouts
+# - For large clusters, consider using serial: parameter to reboot hosts in batches


### PR DESCRIPTION
This pull request introduces updates to improve NFS server handling, enhance debugging capabilities, and add a new playbook for controlled cluster reboots. The changes focus on improving reliability, debugging, and maintenance processes in the Ansible playbooks.

### NFS Server Handling and Debugging:

* Updated the `nfs_server_host` variable in `docker-swarm/group_vars/all.yml` to dynamically resolve the default IPv4 address of the NFS server, ensuring accurate server identification.
* Added a debug task in `docker-swarm/roles/mount_nfs/tasks/main.yml` to display the resolved NFS server host information, aiding in verification and troubleshooting.

### Cluster Maintenance:

* Introduced a new playbook `maintenance/restart-cluster.yml` for controlled cluster node reboots. This playbook includes steps to reboot nodes, verify their successful restart, and handle potential failures, making it suitable for system updates, memory leak resolution, and scheduled maintenance.