### PR TITLE
remove logs for traefik and nfs mount

### DIFF
--- a/deployments/traefik/templates/docker-compose.yaml
+++ b/deployments/traefik/templates/docker-compose.yaml
@@ -21,14 +21,6 @@ services:
       - "--global.sendanonymoususage=false"
       # Disables sending anonymous usage data to Traefik.
 
-      # Logging configuration
-      - "--log.level=DEBUG"
-      # Sets the log level to `DEBUG` for detailed logs. Change to `INFO` or `ERROR` in production.
-      - "--log.filePath=/var/log/traefik/traefik.log"
-      # Specifies the file path for Traefik logs.
-      - "--accesslog.filePath=/var/log/traefik/access.log"
-      # Specifies the file path for access logs.
-
       # API and dashboard
       - "--api.insecure=true"
       # Enables the Traefik API and dashboard without authentication. Use cautiously in production.
@@ -138,8 +130,6 @@ services:
       # Mounts the host's local time configuration as read-only to synchronize the container's time with the host.
       - /var/run/docker.sock:/var/run/docker.sock:ro
       # Mounts the Docker socket as read-only to allow Traefik to interact with the Docker API.
-      - /mnt/nfs/docker/traefik/logs:/var/log/traefik
-      # Mounts the NFS directory for Traefik logs.
       - /mnt/nfs/docker/traefik:/letsencrypt
       # Mounts the NFS directory for storing Let's Encrypt certificates and keys.
 


### PR DESCRIPTION
This pull request simplifies the configuration of the Traefik service in the `docker-compose.yaml` file by removing logging-related settings and associated volume mounts. These changes aim to streamline the setup, likely for environments where logging is handled externally or not required.

### Simplification of Traefik logging configuration:

* Removed logging-related command-line arguments, including log level, log file path, and access log file path. This simplifies the configuration and eliminates the need to manage log files within the container. (`deployments/traefik/templates/docker-compose.yaml`, [deployments/traefik/templates/docker-compose.yamlL24-L31](diffhunk://#diff-f020bfe105a5760a759197bb829d31554139aa869e78f6080a1514281d016b30L24-L31))
* Removed the volume mount for the NFS directory previously used to store Traefik logs. This change complements the removal of logging settings, ensuring no unused mounts are present. (`deployments/traefik/templates/docker-compose.yaml`, [deployments/traefik/templates/docker-compose.yamlL141-L142](diffhunk://#diff-f020bfe105a5760a759197bb829d31554139aa869e78f6080a1514281d016b30L141-L142))