### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,6 +16,11 @@ jobs:
     name: Add issue to project
     # Defines the job to add issues or pull requests to the specified GitHub project.
 
+    permissions:
+      contents: read
+      repository-projects: write
+    # Limits the permissions of the GITHUB_TOKEN to only what is necessary for this job.
+
     runs-on: ubuntu-latest
     # Specifies the environment where the job will run. In this case, it uses the latest Ubuntu runner.
 


### PR DESCRIPTION
Potential fix for [https://github.com/joe-mccarthy/home-lab/security/code-scanning/1](https://github.com/joe-mccarthy/home-lab/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow to explicitly limit the permissions of the `GITHUB_TOKEN`. Based on the workflow's purpose (adding issues or pull requests to a project), the minimal required permissions are likely `contents: read` and `repository-projects: write`. These permissions will allow the workflow to read repository contents and modify the specified GitHub project without granting unnecessary access to other areas.

The `permissions` block will be added at the job level (`add-to-project`) to ensure it applies only to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
